### PR TITLE
Update nfs.mdx

### DIFF
--- a/website/content/docs/synced-folders/nfs.mdx
+++ b/website/content/docs/synced-folders/nfs.mdx
@@ -156,7 +156,7 @@ For macOS, sudoers should have this entry:
 
 ```
 Cmnd_Alias VAGRANT_EXPORTS_ADD = /usr/bin/tee -a /etc/exports
-Cmnd_Alias VAGRANT_NFSD = /sbin/nfsd restart
+Cmnd_Alias VAGRANT_NFSD = /sbin/nfsd ^(restart|status|update)$
 Cmnd_Alias VAGRANT_EXPORTS_REMOVE = /usr/bin/sed -E -e /*/ d -ibak /etc/exports
 %admin ALL=(root) NOPASSWD: VAGRANT_EXPORTS_ADD, VAGRANT_NFSD, VAGRANT_EXPORTS_REMOVE
 ```


### PR DESCRIPTION
current vagrant (2.4.3) on macOS invokes nfs with at least two other arguments (status & update) rather than just restart